### PR TITLE
Support reading blueprints from Apiary #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ Blueprint](http://apiblueprint.org).
 
 ![](screenshots/screen.png)
 
+## Usage
+
+The plugin adds an `apiblueprint` file type along with an `apiblueprint`
+syntax.
+
+### Apiary
+
+You can use the [apiary client](https://github.com/apiaryio/apiary-client) with
+this plugin to load a blueprint from Apiary directly providing apiary client is
+installed and configured.
+
+```shell
+$ vim apiary:pollsapi
+```
+
 ## Installation
 
 ### With [vim-plug](https://github.com/junegunn/vim-plug)

--- a/plugin/apiary.vim
+++ b/plugin/apiary.vim
@@ -6,9 +6,18 @@ function! FetchBlueprint()
   normal gg
 endfunction
 
+function! PublishBlueprint()
+  let api_name = split(expand("%"), ':')[1]
+  let blueprint = join(getline(1, '$'), "\n")
+  let result = system("apiary publish --path=/dev/fd/0 --api-name=" . shellescape(api_name), blueprint)
+  echomsg result
+endfunction
+
 augroup Apiary
   au!
   au BufReadCmd apiary:* call FetchBlueprint()
   au FileReadCmd apiary:* call FetchBlueprint()
+  au BufWriteCmd apiary:* call PublishBlueprint()
+  au FileWriteCmd apiary:* call PublishBlueprint()
 augroup END
 

--- a/plugin/apiary.vim
+++ b/plugin/apiary.vim
@@ -1,0 +1,14 @@
+function! FetchBlueprint()
+  let api_name = split(expand("%"), ':')[1]
+  let blueprint = system("apiary fetch --output=/dev/fd/1 --api-name=" . shellescape(api_name))
+  call append(0, split(blueprint, '\n'))
+  set filetype=apiblueprint
+  normal gg
+endfunction
+
+augroup Apiary
+  au!
+  au BufReadCmd apiary:* call FetchBlueprint()
+  au FileReadCmd apiary:* call FetchBlueprint()
+augroup END
+


### PR DESCRIPTION
Allows reading a blueprint directly from Apiary.

```shell
$ vim apiary:pollsapi
```

### Tasks

- [x] Fetch (read)
- [x] Publish (write)
- [ ] Preview

### Dependencies

- [x] https://github.com/apiaryio/apiary-client/pull/85

![apiblueprint-vim-apiary](https://cloud.githubusercontent.com/assets/44164/8419138/6132a096-1e6c-11e5-87f4-e622a10d8faf.gif)
