### PR TITLE
Highlight JSON as well

### DIFF
--- a/syntax/apiblueprint.vim
+++ b/syntax/apiblueprint.vim
@@ -1,6 +1,8 @@
 runtime! syntax/markdown.vim
 unlet! b:current_syntax
 
+syntax include @json syntax/json.vim
+
 " Metadata
 syntax region apibMarkdownMetadata start=/\%^.*:.*$/ end=/^$/ contains=apibMarkdownMetadataKey,apibMarkdownMetadataValue fold
 syntax match apibMarkdownMetadataKey /^[^:]*\ze:/ contained
@@ -20,6 +22,8 @@ syntax region apibActionRelation start=/^[-+*] Relation: .*$/ end=/$/ oneline co
 syntax match apibHeadersSectionKey /^[^:]*\ze:/ contained
 syntax match apibHeadersSectionValue /:.*/ contained
 
+syntax region apibJSON start=/^\s*{/ end=// contained containedin=markdownCodeBlock contains=@json
+
 highlight default link apibMarkdownMetadataKey Function
 highlight default link apibRequestSection Function
 highlight default link apibResponseSection Function
@@ -30,5 +34,6 @@ highlight default link apibHTTPContentType Comment
 highlight default link apibActionRelation Function
 highlight default link apibActionRelationKey Identifier
 
-let b:current_syntax = 'apiblueprint'
+syn sync fromstart
 
+let b:current_syntax = 'apiblueprint'


### PR DESCRIPTION
This uses a stupid heuristic that code blocks starting with { are JSON, so it 
may cause problems for other content-types and I'm not sure how to do this 
properly. :-(